### PR TITLE
fix: Properly handle progress data

### DIFF
--- a/apps/web/app/user/progress/page.tsx
+++ b/apps/web/app/user/progress/page.tsx
@@ -16,32 +16,7 @@ import {
     fetchInstructorStats,
     fetchMasteredDanceCategories
 } from "@/lib/api/enroll";
-
-// const categoryChartData = [
-//     { name: "BALLET", value: 15.2 },
-//     { name: "CONTEMPORARY", value: 8.3 },
-//     { name: "JAZZ", value: 12.8 },
-//     { name: "HIP HOP", value: 19.5 },
-//     { name: "LATIN", value: 6.7 },
-// ];
-
-// const instructorChartData = [
-//     { name: "John Doe", value: 15.2 },
-//     { name: "Jane Smith", value: 8.3 },
-//     { name: "Jim Kelly", value: 12.8 },
-//     { name: "Jill Johnson", value: 19.5 },
-//     { name: "Jack Anderson", value: 6.7 },
-// ];
-
-// const ongoingCourses = [
-//     { primaryText: "Ballet Mastery", secondaryText: "Attendance: 10/15", tertiaryText: "Instructor: John Doe" },
-//     { primaryText: "Latin for beginners", secondaryText: "Attendance: 12/15", tertiaryText: "Instructor: Jane Smith" },
-// ];
-
-// const mastered = [
-//     { primaryText: "Ballet, Advanced", secondaryText: "Mastered 29.09.2025", tertiaryText: "Instructor: John Doe" },
-//     { primaryText: "Jazz, Intermediate", secondaryText: "Mastered 16.06.2025", tertiaryText: "Instructor: Jane Smith" },
-// ];
+import { headers } from 'next/headers';
 
 const ongoingCoursesEmptyState = {
     title: "No ongoing courses",
@@ -54,10 +29,12 @@ const masteredEmptyState = {
 };
 
 export default async function Page() {
-    const danceCategoryStats = await fetchDanceCategoryStats();
-    const instructorStats = await fetchInstructorStats();
-    const courseAttendanceRate = await fetchCourseAttendanceRate();
-    const masteredDanceCategories = await fetchMasteredDanceCategories();
+    const cookie = (await headers()).get('cookie') ?? "";
+
+    const danceCategoryStats = await fetchDanceCategoryStats(cookie);
+    const instructorStats = await fetchInstructorStats(cookie);
+    const courseAttendanceRate = await fetchCourseAttendanceRate(cookie);
+    const masteredDanceCategories = await fetchMasteredDanceCategories(cookie);
 
     const categoryChartData = transformDanceCategoryStatsToChartData(danceCategoryStats.data?.spentHoursStatsList || []);
     const instructorChartData = transformInstructorStatsToChartData(instructorStats.data?.spentHoursStatsList || []);

--- a/apps/web/lib/model/enroll.ts
+++ b/apps/web/lib/model/enroll.ts
@@ -28,7 +28,7 @@ export type MasteredDanceCategoriesResponse = MasteredDanceCategory[];
 
 export type DanceCategoryStats = {
   danceCategoryName: string;
-  hoursSpent: number;
+  spentHours: number;
 };
 
 export type DanceCategoryStatsResponse = {
@@ -38,7 +38,7 @@ export type DanceCategoryStatsResponse = {
 export type InstructorStats = {
   instructorFirstname: string;
   instructorSurname: string;
-  hoursSpent: number;
+  spentHours: number;
 };
 
 export type InstructorStatsResponse = {

--- a/apps/web/lib/utils/progress-transformers.ts
+++ b/apps/web/lib/utils/progress-transformers.ts
@@ -8,7 +8,7 @@ import { DanceCategoryStats, InstructorStats, CourseAttendanceRate, MasteredDanc
 export function transformDanceCategoryStatsToChartData(stats: DanceCategoryStats[]) {
   return stats.map(stat => ({
     name: stat.danceCategoryName,
-    value: stat.hoursSpent
+    value: stat.spentHours
   }));
 }
 
@@ -20,7 +20,7 @@ export function transformDanceCategoryStatsToChartData(stats: DanceCategoryStats
 export function transformInstructorStatsToChartData(stats: InstructorStats[]) {
   return stats.map(stat => ({
     name: `${stat.instructorFirstname} ${stat.instructorSurname}`,
-    value: stat.hoursSpent
+    value: stat.spentHours
   }));
 }
 
@@ -58,7 +58,7 @@ export function transformMasteredCategoriesToProgressItems(mastered: MasteredDan
  * @returns Total number of hours spent across all categories
  */
 export function calculateTotalHours(stats: DanceCategoryStats[]): number {
-  return stats.reduce((total, stat) => total + stat.hoursSpent, 0);
+  return stats.reduce((total, stat) => total + stat.spentHours, 0);
 }
 
 /**


### PR DESCRIPTION
Path `/user/progress` now shows progress data (fetched from API) properly. Example for mock user with ID=61:

<img width="1705" height="1237" alt="Screenshot 2025-10-11 at 20 37 29" src="https://github.com/user-attachments/assets/bfa90065-a3d6-4ca3-b89c-afe97b3c3cf4" />
